### PR TITLE
Quick fix for data import error.

### DIFF
--- a/usda_nutrition/management/commands/import_usda.py
+++ b/usda_nutrition/management/commands/import_usda.py
@@ -70,7 +70,7 @@ INPUT_FILES = (
 
 def value_for_field(field, value):
     # Convert Y/N into a boolean.
-    if type(field) == models.BooleanField:
+    if type(field) in [models.BooleanField, models.NullBooleanField]:
         return {
             'Y': True,
             'N': False,


### PR DESCRIPTION
After installing the app from pip I was getting the error: 'django.core.exceptions.ValidationError: ["'Y' value must be either None, True or False."]', while loading 'FOOD_DES.txt'. The 'survey' field in FoodDescription is a NullBooleanField, which wasn't covered in the value_for_field function. I'm using python 3.6.0, django 1.11.3. Thanks.

Looks like BooleanField isn't actually used in models, so it could probably just be changed to NullBooleanField. Looking at Django source for 1.11.3, NullBooleanField and BooleanField both subclass Field, so that seems why it wasn't caught in the if statement.